### PR TITLE
Add diagnostic logs to the apple id authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.apple/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/pom.xml
@@ -170,6 +170,7 @@
                             org.wso2.carbon.user.core.tenant; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",
+                            org.wso2.carbon.utils.*; version="${carbon.kernel.package.import.version.range}",
 
                             org.apache.commons.lang; version="${org.apache.commons.lang.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
@@ -181,6 +182,8 @@
                             org.wso2.carbon.identity.application.authentication.framework.context;
                             version="${identity.framework.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.exception;
+                            version="${identity.framework.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.util;
                             version="${identity.framework.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model;
                             version="${identity.framework.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorConstants.java
@@ -48,4 +48,21 @@ public class AppleAuthenticatorConstants {
     public static final String APPLE_TOKEN_ENDPOINT = "AppleTokenEndpoint";
     public static final String APPLE_USER_INFO_KEY = "user";
     public static final String CLAIM_DIALECT_URI_PARAMETER = "ClaimDialectUri";
+
+    /**
+     * Constants related to log management.
+     */
+    public static class LogConstants {
+
+        public static final String OUTBOUND_AUTH_APPLE_SERVICE = "outbound-auth-apple";
+
+        /**
+         * Define action IDs for diagnostic logs.
+         */
+        public static class ActionIDs {
+
+            public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-outbound-auth-oidc-response";
+            public static final String VALIDATE_OUTBOUND_AUTH_REQUEST = "initiate-outbound-auth-oidc-request";
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
@@ -45,6 +45,7 @@ import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorC
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -96,6 +97,7 @@ public class AppleAuthenticatorTest {
     private FileBasedConfigurationBuilder fileBasedConfigurationBuilderMock;
     private MockedStatic<FileBasedConfigurationBuilder> fileBasedConfigurationBuilder;
     private MockedStatic<AppleAuthenticatorDataHolder> appleAuthenticatorDataHolder;
+    private MockedStatic<LoggerUtils> loggerUtilsMock;
 
     private static final String TEST_EMAIL = "user@test.com";
     private static final String TEST_TENANT = "testtenant";
@@ -132,6 +134,9 @@ public class AppleAuthenticatorTest {
         appleAuthenticatorDataHolder.when(AppleAuthenticatorDataHolder::getInstance).thenReturn(
                 appleAuthenticatorDataHolderMock);
         when(appleAuthenticatorDataHolderMock.getRealmService()).thenReturn(realmServiceMock);
+
+        loggerUtilsMock = mockStatic(LoggerUtils.class);
+        loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
     }
 
     @AfterClass

--- a/pom.xml
+++ b/pom.xml
@@ -322,17 +322,17 @@
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
 
         <!-- kernel and framework dependencies -->
-        <carbon.kernel.version>4.9.0</carbon.kernel.version>
-        <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
+        <carbon.kernel.version>4.9.10</carbon.kernel.version>
+        <carbon.kernel.package.import.version.range>[4.9.10, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
-        <carbon.identity.framework.version>5.25.42</carbon.identity.framework.version>
-        <identity.framework.package.import.version.range>[5.14.0, 7.0.0)</identity.framework.package.import.version.range>
+        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
+        <identity.framework.package.import.version.range>[5.25.260, 7.0.0)</identity.framework.package.import.version.range>
 
         <!-- other wso2 dependencies -->
-        <identity.outbound.auth.oidc.version>5.11.2</identity.outbound.auth.oidc.version>
-        <carbon.identity.outbound.oidc.package.import.version.range>[5.0.0, 6.0.0)</carbon.identity.outbound.oidc.package.import.version.range>
-        <carbon.identity.oauth.version>6.2.0</carbon.identity.oauth.version>
+        <identity.outbound.auth.oidc.version>5.11.18</identity.outbound.auth.oidc.version>
+        <carbon.identity.outbound.oidc.package.import.version.range>[5.11.18, 6.0.0)</carbon.identity.outbound.oidc.package.import.version.range>
+        <carbon.identity.oauth.version>6.11.97</carbon.identity.oauth.version>
         <carbon.identity.oauth.package.import.version.range>[6.2.0, 7.0.0)</carbon.identity.oauth.package.import.version.range>
 
         <!-- other dependencies -->


### PR DESCRIPTION
## Purpose
$subject

## Approach
Similar to the https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/147 diagnostics logs will be added to the same flows.