### PR TITLE
Modify apple authenticator to enable federation flow in API based Authentication and Nonce validation

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticator.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.apple.internal.AppleAuthenticatorDataHolder;
 import org.wso2.carbon.identity.application.authenticator.apple.util.AppleUtil;
@@ -87,8 +88,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authenticator.apple.AppleAuthenticatorConstants.AUTHENTICATOR_APPLE;
+import static org.wso2.carbon.identity.application.authenticator.apple.AppleAuthenticatorConstants.COMMA_SEPARATOR;
 import static org.wso2.carbon.identity.application.authenticator.apple.AppleAuthenticatorConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
 import static org.wso2.carbon.identity.application.authenticator.apple.AppleAuthenticatorConstants.LogConstants.ActionIDs.VALIDATE_OUTBOUND_AUTH_REQUEST;
+import static org.wso2.carbon.identity.application.authenticator.apple.AppleAuthenticatorConstants.PLUS_SEPARATOR;
+import static org.wso2.carbon.identity.application.authenticator.apple.AppleAuthenticatorConstants.SPACE_SEPARATOR;
 import static org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants.Claim.NONCE;
 import static org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants.OIDC_FEDERATION_NONCE;
 import static org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants.REDIRECT_URL_SUFFIX;
@@ -697,7 +701,7 @@ public class AppleAuthenticator extends OpenIDConnectAuthenticator {
 
         String scopes = authenticatorProperties.get(IdentityApplicationConstants.Authenticator.OIDC.SCOPES);
         if (StringUtils.isNotBlank(scopes)) {
-            return scopes.replace(",", " ").replace("+", " ");
+            return scopes.replace(COMMA_SEPARATOR, SPACE_SEPARATOR).replace(PLUS_SEPARATOR, SPACE_SEPARATOR);
         }
         return scopes;
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticator.java
@@ -38,7 +38,6 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.apple.internal.AppleAuthenticatorDataHolder;
 import org.wso2.carbon.identity.application.authenticator.apple.util.AppleUtil;

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticator.java
@@ -152,9 +152,9 @@ public class AppleAuthenticator extends OpenIDConnectAuthenticator {
                 String authorizationEP = getAuthorizationServerEndpoint(authenticatorProperties);
                 String callbackUrl = getCallBackURL(context, authenticatorProperties);
                 String state = getStateParameter(request, context, authenticatorProperties);
-                context.setProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME + STATE_PARAM_SUFFIX, state);
+                context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + STATE_PARAM_SUFFIX, state);
                 String scopes = getScope(authenticatorProperties);
-                context.setProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME + SCOPE_PARAM_SUFFIX, scopes);
+                context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + SCOPE_PARAM_SUFFIX, scopes);
                 String queryString = getQueryString(authenticatorProperties);
 
                 // If scopes are present, Apple requires sending response_mode as form_post.
@@ -208,7 +208,7 @@ public class AppleAuthenticator extends OpenIDConnectAuthenticator {
                         loginPage = loginPage + queryString;
                     }
                 }
-                context.setProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME + REDIRECT_URL_SUFFIX, loginPage);
+                context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + REDIRECT_URL_SUFFIX, loginPage);
                 response.sendRedirect(response.encodeRedirectURL(loginPage.replace("\r\n", "")));
                 if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
                     diagnosticLogBuilder.resultMessage("Redirected to the Apple Id login page.");

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticator.java
@@ -155,9 +155,9 @@ public class AppleAuthenticator extends OpenIDConnectAuthenticator {
                     callbackUrl = resolveCallBackURLForAPIBasedAuthFlow(context);
                 }
                 String state = getStateParameter(request, context, authenticatorProperties);
-                context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + STATE_PARAM_SUFFIX, state);
+                context.setProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME + STATE_PARAM_SUFFIX, state);
                 String scopes = getScope(authenticatorProperties);
-                context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + SCOPE_PARAM_SUFFIX, scopes);
+                context.setProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME + SCOPE_PARAM_SUFFIX, scopes);
                 String queryString = getQueryString(authenticatorProperties);
 
                 // If scopes are present, Apple requires sending response_mode as form_post.
@@ -211,7 +211,7 @@ public class AppleAuthenticator extends OpenIDConnectAuthenticator {
                         loginPage = loginPage + queryString;
                     }
                 }
-                context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + REDIRECT_URL_SUFFIX, loginPage);
+                context.setProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME + REDIRECT_URL_SUFFIX, loginPage);
                 response.sendRedirect(response.encodeRedirectURL(loginPage.replace("\r\n", "")));
                 if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
                     diagnosticLogBuilder.resultMessage("Redirected to the Apple Id login page.");

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorConstants.java
@@ -49,7 +49,6 @@ public class AppleAuthenticatorConstants {
     public static final String APPLE_USER_INFO_KEY = "user";
     public static final String CLAIM_DIALECT_URI_PARAMETER = "ClaimDialectUri";
 
-    public static final String IS_API_BASED = "IS_API_BASED";
     public static final String AUTHENTICATOR_APPLE = "authenticator.apple";
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorConstants.java
@@ -49,6 +49,9 @@ public class AppleAuthenticatorConstants {
     public static final String APPLE_USER_INFO_KEY = "user";
     public static final String CLAIM_DIALECT_URI_PARAMETER = "ClaimDialectUri";
 
+    public static final String IS_API_BASED = "IS_API_BASED";
+    public static final String AUTHENTICATOR_APPLE = "authenticator.apple";
+
     /**
      * Constants related to log management.
      */

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorConstants.java
@@ -51,6 +51,10 @@ public class AppleAuthenticatorConstants {
 
     public static final String AUTHENTICATOR_APPLE = "authenticator.apple";
 
+    public static final String COMMA_SEPARATOR = ",";
+    public static final String PLUS_SEPARATOR = "+";
+    public static final String SPACE_SEPARATOR = " ";
+
     /**
      * Constants related to log management.
      */

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
@@ -237,11 +237,11 @@ public class AppleAuthenticatorTest {
         if (isAPIBased) {
             Assert.assertTrue(Boolean.parseBoolean(
                     (String) authenticationContext.getProperty(FrameworkConstants.IS_API_BASED)));
-            Assert.assertNotNull(authenticationContext.getProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME
+            Assert.assertNotNull(authenticationContext.getProperty(appleAuthenticator.getName()
                     + STATE_PARAM_SUFFIX));
-            Assert.assertNotNull(authenticationContext.getProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME
+            Assert.assertNotNull(authenticationContext.getProperty(appleAuthenticator.getName()
                     + SCOPE_PARAM_SUFFIX));
-            String redirectUrlPropertyKey = OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + REDIRECT_URL_SUFFIX;
+            String redirectUrlPropertyKey = appleAuthenticator.getName() + REDIRECT_URL_SUFFIX;
             Assert.assertNotNull(authenticationContext.getProperty(redirectUrlPropertyKey));
             // For API based auth flow, the redirect URL should not be equal to commonauth endpoint.
             Assert.assertFalse(redirectUrl.contains("https://localhost:9443/commonauth"));

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
@@ -237,11 +237,11 @@ public class AppleAuthenticatorTest {
         if (isAPIBased) {
             Assert.assertTrue(Boolean.parseBoolean(
                     (String) authenticationContext.getProperty(FrameworkConstants.IS_API_BASED)));
-            Assert.assertNotNull(authenticationContext.getProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME
+            Assert.assertNotNull(authenticationContext.getProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME
                     + STATE_PARAM_SUFFIX));
-            Assert.assertNotNull(authenticationContext.getProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME
+            Assert.assertNotNull(authenticationContext.getProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME
                     + SCOPE_PARAM_SUFFIX));
-            String redirectUrlPropertyKey = AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME + REDIRECT_URL_SUFFIX;
+            String redirectUrlPropertyKey = OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + REDIRECT_URL_SUFFIX;
             Assert.assertNotNull(authenticationContext.getProperty(redirectUrlPropertyKey));
             // For API based auth flow, the redirect URL should not be equal to commonauth endpoint.
             Assert.assertFalse(redirectUrl.contains("https://localhost:9443/commonauth"));

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
@@ -247,7 +247,8 @@ public class AppleAuthenticatorTest {
         }
     }
 
-    @Test(dataProvider = "initiateAuthenticationRequestDataProvider")
+    @Test(dataProvider = "initiateAuthenticationRequestDataProvider",
+            dependsOnMethods = {"testInitiateAuthenticationRequest"})
     public void testInitiateAuthenticationRequestForAPIBased(String secretGenerateCondition)
             throws AuthenticationFailedException, IOException, IdentityProviderManagementException {
 

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
@@ -77,6 +77,9 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants.REDIRECT_URL_SUFFIX;
+import static org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants.SCOPE_PARAM_SUFFIX;
+import static org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants.STATE_PARAM_SUFFIX;
 
 /**
  * Unit tests for the Apple authenticator class.
@@ -87,6 +90,7 @@ public class AppleAuthenticatorTest {
     private static Map<String, String> testAuthenticatorProperties;
     private static AuthenticatorConfig authenticatorConfig;
     private static AuthenticationContext authenticationContext;
+    private static boolean isAPIBased;
 
     private AutoCloseable autoCloseable;
     @Mock
@@ -228,6 +232,27 @@ public class AppleAuthenticatorTest {
         Assert.assertTrue(redirectUrl.contains("client_id=testClientId"));
         Assert.assertTrue(redirectUrl.contains("scope=name%20email"));
         Assert.assertTrue(redirectUrl.contains("response_mode=form_post"));
+
+        if (isAPIBased) {
+            Assert.assertTrue(Boolean.parseBoolean(
+                    (String) authenticationContext.getProperty(AppleAuthenticatorConstants.IS_API_BASED)));
+            Assert.assertNotNull(authenticationContext.getProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME
+                    + STATE_PARAM_SUFFIX));
+            Assert.assertNotNull(authenticationContext.getProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME
+                    + SCOPE_PARAM_SUFFIX));
+            String redirectUrlPropertyKey = AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME + REDIRECT_URL_SUFFIX;
+            Assert.assertNotNull(authenticationContext.getProperty(redirectUrlPropertyKey));
+            // For API based auth flow, the redirect URL should not be equal to commonauth endpoint.
+            Assert.assertTrue(redirectUrl.contains("https://localhost:9443/commonauth"));
+        }
+    }
+
+    @Test(dataProvider = "initiateAuthenticationRequestDataProvider")
+    public void testInitiateAuthenticationRequestForAPIBased(String secretGenerateCondition)
+            throws AuthenticationFailedException, IOException, IdentityProviderManagementException {
+
+        isAPIBased = true;
+        testInitiateAuthenticationRequest(secretGenerateCondition);
     }
 
     @DataProvider(name = "initiateAuthenticationRequestExceptionDataProvider")
@@ -522,6 +547,20 @@ public class AppleAuthenticatorTest {
         });
     }
 
+    @Test
+    public void testGetI18nKey() {
+
+        String facebookI18nKey = appleAuthenticator.getI18nKey();
+        Assert.assertEquals(facebookI18nKey, AppleAuthenticatorConstants.AUTHENTICATOR_APPLE);
+    }
+
+    @Test
+    public void testIsAPIBasedAuthenticationSupported() {
+
+        boolean isAPIBasedAuthenticationSupported = appleAuthenticator.isAPIBasedAuthenticationSupported();
+        Assert.assertTrue(isAPIBasedAuthenticationSupported);
+    }
+
     private void initAuthenticatorProperties() {
 
         testAuthenticatorProperties = new HashMap<>();
@@ -569,5 +608,9 @@ public class AppleAuthenticatorTest {
         authenticationContext.setTenantDomain(TEST_TENANT);
         authenticationContext.setExternalIdP(externalIdPConfig);
         authenticationContext.setContextIdentifier(CONTEXT_IDENTIFIER);
+
+        if (isAPIBased) {
+            authenticationContext.setProperty(AppleAuthenticatorConstants.IS_API_BASED, "true");
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthResponseWrapper;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authenticator.apple.internal.AppleAuthenticatorDataHolder;
 import org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.oidc.model.OIDCStateInfo;
@@ -235,7 +236,7 @@ public class AppleAuthenticatorTest {
 
         if (isAPIBased) {
             Assert.assertTrue(Boolean.parseBoolean(
-                    (String) authenticationContext.getProperty(AppleAuthenticatorConstants.IS_API_BASED)));
+                    (String) authenticationContext.getProperty(FrameworkConstants.IS_API_BASED)));
             Assert.assertNotNull(authenticationContext.getProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME
                     + STATE_PARAM_SUFFIX));
             Assert.assertNotNull(authenticationContext.getProperty(AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME
@@ -611,7 +612,7 @@ public class AppleAuthenticatorTest {
         authenticationContext.setContextIdentifier(CONTEXT_IDENTIFIER);
 
         if (isAPIBased) {
-            authenticationContext.setProperty(AppleAuthenticatorConstants.IS_API_BASED, "true");
+            authenticationContext.setProperty(FrameworkConstants.IS_API_BASED, "true");
         }
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/test/java/org/wso2/carbon/identity/application/authenticator/apple/AppleAuthenticatorTest.java
@@ -243,7 +243,7 @@ public class AppleAuthenticatorTest {
             String redirectUrlPropertyKey = AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME + REDIRECT_URL_SUFFIX;
             Assert.assertNotNull(authenticationContext.getProperty(redirectUrlPropertyKey));
             // For API based auth flow, the redirect URL should not be equal to commonauth endpoint.
-            Assert.assertTrue(redirectUrl.contains("https://localhost:9443/commonauth"));
+            Assert.assertFalse(redirectUrl.contains("https://localhost:9443/commonauth"));
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <identity.framework.package.import.version.range>[5.25.260, 8.0.0)</identity.framework.package.import.version.range>
 
         <!-- other wso2 dependencies -->
-        <identity.outbound.auth.oidc.version>5.12.10</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.12.11</identity.outbound.auth.oidc.version>
         <carbon.identity.outbound.oidc.package.import.version.range>[5.11.18, 6.0.0)</carbon.identity.outbound.oidc.package.import.version.range>
         <carbon.identity.oauth.version>6.11.97</carbon.identity.oauth.version>
         <carbon.identity.oauth.package.import.version.range>[6.2.0, 8.0.0)</carbon.identity.oauth.package.import.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -326,11 +326,11 @@
         <carbon.kernel.package.import.version.range>[4.9.10, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
-        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.560</carbon.identity.framework.version>
         <identity.framework.package.import.version.range>[5.25.260, 8.0.0)</identity.framework.package.import.version.range>
 
         <!-- other wso2 dependencies -->
-        <identity.outbound.auth.oidc.version>5.11.18</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.12.3</identity.outbound.auth.oidc.version>
         <carbon.identity.outbound.oidc.package.import.version.range>[5.11.18, 6.0.0)</carbon.identity.outbound.oidc.package.import.version.range>
         <carbon.identity.oauth.version>6.11.97</carbon.identity.oauth.version>
         <carbon.identity.oauth.package.import.version.range>[6.2.0, 8.0.0)</carbon.identity.oauth.package.import.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <identity.framework.package.import.version.range>[5.25.260, 8.0.0)</identity.framework.package.import.version.range>
 
         <!-- other wso2 dependencies -->
-        <identity.outbound.auth.oidc.version>5.12.3</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.12.10</identity.outbound.auth.oidc.version>
         <carbon.identity.outbound.oidc.package.import.version.range>[5.11.18, 6.0.0)</carbon.identity.outbound.oidc.package.import.version.range>
         <carbon.identity.oauth.version>6.11.97</carbon.identity.oauth.version>
         <carbon.identity.oauth.package.import.version.range>[6.2.0, 8.0.0)</carbon.identity.oauth.package.import.version.range>


### PR DESCRIPTION
This PR includes the below given changes
- Enables API based authentication with federation flow for Apple authenticator. This supports both Native mode and Redirection mode.
- Enable nonce validation for apple authenticator.

Related issue:
- https://github.com/wso2/product-is/issues/20584

Merge the PR after merging the below given PR and bumping the oidc version:
- https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/186

**Sample Responses**

1. Initial `/authorize` request
```
{
    "flowId": "44f86b73-55fd-4ec5-8571-c7f4049d3c07",
    "flowStatus": "INCOMPLETE",
    "flowType": "AUTHENTICATION",
    "nextStep": {
        "stepType": "MULTI_OPTIONS_PROMPT",
        "authenticators": [
            {
                "authenticatorId": "R29vZ2xlT0lEQ0F1dGhlbnRpY2F0b3I6R29vZ2xl",
                "authenticator": "Google",
                "idp": "Google",
                "metadata": {
                    "i18nKey": "authenticator.google"
                }
            },
            {
                "authenticatorId": "QXBwbGVPSURDQXV0aGVudGljYXRvcjpBcHBsZQ",
                "authenticator": "Apple",
                "idp": "Apple",
                "metadata": {
                    "i18nKey": "authenticator.apple"
                }
            }
        ]
    },
    "links": [
        {
            "name": "authentication",
            "href": "https://wso2is.com:9443/oauth2/authn",
            "method": "POST"
        }
    ]
}
```

2. `/authn` request (Native mode)
```
{
    "flowId": "44f86b73-55fd-4ec5-8571-c7f4049d3c07",
    "flowStatus": "INCOMPLETE",
    "flowType": "AUTHENTICATION",
    "nextStep": {
        "stepType": "AUTHENTICATOR_PROMPT",
        "authenticators": [
            {
                "authenticatorId": "QXBwbGVPSURDQXV0aGVudGljYXRvcjpBcHBsZQ",
                "authenticator": "Apple",
                "idp": "Apple",
                "metadata": {
                    "i18nKey": "authenticator.apple",
                    "promptType": "INTERNAL_PROMPT",
                    "additionalData": {
                        "clientId": "com.asgupgrade.stage",
                        "scope": "email name"
                    }
                },
                "requiredParams": [
                    "accessToken",
                    "idToken"
                ]
            }
        ]
    },
    "links": [
        {
            "name": "authentication",
            "href": "https://wso2is.com:9443/oauth2/authn",
            "method": "POST"
        }
    ]
}
```

3. `/authn` request (Redirection mode)
```
{
    "flowId": "44f86b73-55fd-4ec5-8571-c7f4049d3c07",
    "flowStatus": "INCOMPLETE",
    "flowType": "AUTHENTICATION",
    "nextStep": {
        "stepType": "AUTHENTICATOR_PROMPT",
        "authenticators": [
            {
                "authenticatorId": "QXBwbGVPSURDQXV0aGVudGljYXRvcjpBcHBsZQ",
                "authenticator": "Apple",
                "idp": "Apple",
                "metadata": {
                    "i18nKey": "authenticator.apple",
                    "promptType": "REDIRECTION_PROMPT",
                    "additionalData": {
                        "state": "43fa600f-0ad3-4170-80e8-d8e615d59e09,OIDC",
                        "redirectUrl": "https://appleid.apple.com/auth/authorize?response_type=code&state=43fa600f-0ad3-4170-80e8-d8e615d59e09%2COIDC&redirect_uri=https%3A%2F%2Fgoogle.com&client_id=com.asgupgrade.stage&scope=email%20name&response_mode=form_post"
                    }
                },
                "requiredParams": [
                    "code",
                    "state"
                ]
            }
        ]
    },
    "links": [
        {
            "name": "authentication",
            "href": "https://wso2is.com:9443/oauth2/authn",
            "method": "POST"
        }
    ]
}
```

Related links:
[1] https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest/nonce

Sample JWT Payload from apple IDP
```
{
  "iss": "https://appleid.apple.com",
  "aud": "com.asgupgrade.stage",
  "exp": 1720100111,
  "iat": 1720013711,
  "sub": "001094.77fd79fb64a1413398438254b1a28e64.0535",
  "nonce": "f9945071-859e-4d2a-a6e4-5b435f16d109",
  "at_hash": "LfD82O14Te81Z_jqY6fAuQ",
  "email": "ziyam@wso2.com",
  "email_verified": true,
  "auth_time": 1720013689,
  "nonce_supported": true
}
```