### PR TITLE
Override getAMRValue method

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/executor/AppleExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.apple/src/main/java/org/wso2/carbon/identity/application/authenticator/apple/executor/AppleExecutor.java
@@ -48,6 +48,12 @@ public class AppleExecutor extends OpenIDConnectExecutor {
     }
 
     @Override
+    public String getAMRValue() {
+
+        return AppleAuthenticatorConstants.APPLE_CONNECTOR_NAME;
+    }
+
+    @Override
     public String getAuthorizationServerEndpoint(Map<String, String> authenticatorProperties) {
 
         String authzEndpoint = authenticatorProperties.get(AppleAuthenticatorConstants.APPLE_AUTHZ_ENDPOINT);

--- a/pom.xml
+++ b/pom.xml
@@ -326,11 +326,11 @@
         <carbon.kernel.package.import.version.range>[4.9.10, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
-        <carbon.identity.framework.version>7.8.241</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
         <identity.framework.package.import.version.range>[5.25.260, 8.0.0)</identity.framework.package.import.version.range>
 
         <!-- other wso2 dependencies -->
-        <identity.outbound.auth.oidc.version>5.12.32</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.12.36</identity.outbound.auth.oidc.version>
         <carbon.identity.outbound.oidc.package.import.version.range>[5.11.18, 6.0.0)</carbon.identity.outbound.oidc.package.import.version.range>
         <carbon.identity.oauth.version>6.11.97</carbon.identity.oauth.version>
         <carbon.identity.oauth.package.import.version.range>[6.2.0, 8.0.0)</carbon.identity.oauth.package.import.version.range>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

This pull request introduces a minor feature enhancement to the Apple authenticator executor and updates dependency versions in the project configuration. The main changes are grouped into authenticator improvements and dependency updates.

Authenticator improvements:

* Added the `getAMRValue()` method to the `AppleExecutor` class to return the Apple connector name, improving support for Authentication Method Reference (AMR) values.

Dependency updates:

* Updated `carbon.identity.framework.version` from `7.8.241` to `7.8.403` and `identity.outbound.auth.oidc.version` from `5.12.32` to `5.12.36` in `pom.xml`, ensuring the project uses the latest compatible versions of these dependencies.